### PR TITLE
Show sampling statistics

### DIFF
--- a/djdt_flamegraph/djdt_flamegraph.py
+++ b/djdt_flamegraph/djdt_flamegraph.py
@@ -1,5 +1,7 @@
 import collections
 import signal
+import time
+import math
 
 from django.template import Template, Context
 
@@ -27,6 +29,21 @@ template = r"""
     <script>
         init();
     </script>
+    <div style="padding: 1ex">
+      Total time: {{ stats.total_time|floatformat:"0" }} ms <br>
+      Sampling overhead: {{ stats.sampling_cost|floatformat:"0" }} ms
+        ({{ stats.sampling_cost_per_sample|floatformat }} &micro;s per sample) <br>
+      Samples: {{ stats.samples }} (expected: {{ stats.expected_samples|floatformat:"0" }}) <br>
+      Interval: {{ stats.min_interval|floatformat:"-3" }}..{{ stats.max_interval|floatformat:"-3" }} ms
+                (average {{ stats.avg_interval|floatformat:"-3" }} ms, stddev {{ stats.stddev|floatformat:"-3" }} ms) <br>
+      Outliers:
+      {% for outlier in stats.outliers %}
+        {{ outlier|floatformat:"-3"}}&#x200a;ms
+      {% endfor %}
+      {% for outlier in stats.serious_outliers %}
+        <b title="sample {{ outlier.pos }} of {{ stats.samples }}">{{ outlier.value|floatformat:"-3"}}&#x200a;ms</b>
+      {% endfor %}
+    </div>
 </template>
 <iframe id="djdt-flamegraph-iframe" style="width:100%;height:100%;" src="about:blank">
 </iframe>
@@ -52,7 +69,8 @@ class FlamegraphPanel(Panel):
     @property
     def content(self):
         ctx = {
-            'flamegraph': flamegraph.stats_to_svg(self.sampler.get_stats())
+            'flamegraph': flamegraph.stats_to_svg(self.sampler.get_stats()),
+            'stats': self.sampler.get_sampling_stats(),
         }
         return Template(template).render(Context(ctx))
 
@@ -70,8 +88,13 @@ class Sampler(object):
     def __init__(self, interval=0.001):
         self.stack_counts = collections.defaultdict(int)
         self.interval = interval
+        self.sampling_cost = 0
+        self.total_time = 0
+        self.intervals = []
+        self._start = self._last = 0
 
     def _sample(self, signum, frame):
+        now = time.time()
         stack = []
         while frame is not None:
             formatted_frame = '{}({})'.format(frame.f_code.co_name,
@@ -81,13 +104,71 @@ class Sampler(object):
 
         formatted_stack = ';'.join(reversed(stack))
         self.stack_counts[formatted_stack] += 1
+        self.intervals.append(now - self._last)
+        self._last = now
+        self.sampling_cost += time.time() - now
 
     def get_stats(self):
         return '\n'.join('%s %d' % (key, value) for key, value in sorted(self.stack_counts.items()))
 
+    def get_sampling_stats(self):
+        intervals, outliers = split_outliers(self.intervals)
+        serious_threshold = self.interval * 10
+        serious_outliers = [
+            {'value': o * 1000,
+             'pos': self.intervals.index(o)}
+            for o in outliers if o >= serious_threshold
+        ]
+        outliers = [o for o in outliers if o < serious_threshold]
+        return {
+            'sampling_cost': self.sampling_cost * 1000,
+            'sampling_cost_per_sample': 'n/a' if not self.intervals else 1e6 * self.sampling_cost / len(self.intervals),
+            'interval': self.interval * 1000,
+            'min_interval': min(intervals) * 1000,
+            'max_interval': max(intervals) * 1000,
+            'avg_interval': avg(intervals) * 1000,
+            'stddev': stddev(intervals) * 1000,
+            'outliers': [o * 1000 for o in outliers],
+            'serious_outliers': serious_outliers,
+            'total_time': self.total_time * 1000,
+            'samples': len(self.intervals),
+            'expected_samples': self.total_time / self.interval,
+        }
+
     def start(self):
+        self._start = self._last = time.time()
         signal.signal(signal.SIGALRM, self._sample)
         signal.setitimer(signal.ITIMER_REAL, self.interval, self.interval)
 
     def stop(self):
         signal.setitimer(signal.ITIMER_REAL, 0, 0)
+        self.total_time = time.time() - self._start
+
+
+def avg(numbers):
+    return sum(numbers) / len(numbers) if numbers else 'n/a'
+
+
+def stddev(numbers):
+    if len(numbers) < 2:
+        return 'n/a'
+    c = avg(numbers)
+    ss = sum((x - c) ** 2 for x in numbers)
+    # XXX: divide by len(numbers) - 1 maybe?  lol I don't know stats
+    return math.sqrt(ss / len(numbers))
+
+
+def split_outliers(numbers):
+    numbers = sorted(numbers)
+    outliers = []
+    if len(numbers) < 10:
+        return numbers, outliers
+    q1 = numbers[len(numbers) // 4]
+    q3 = numbers[len(numbers) * 3 // 4]
+    iqr = q3 - q1
+    f = 15  # usually 1.5 but I want fewer outliers -- only those that are seriously out there
+    min_x = q1 - f * iqr
+    max_x = q3 + f * iqr
+    outliers = [x for x in numbers if x < min_x or x > max_x]
+    numbers = [x for x in numbers if min_x <= x <= max_x]
+    return numbers, outliers


### PR DESCRIPTION
Background: I was trying to profile a view that took ~5 seconds to
render.  I saw that my flamegraph contained ~1000 samples where I
expected closer to 5000, given the 1ms sampling interval.  I decided
that I needed to know how accurate the sampling was.

This commit records time.time() deltas between each sample and tries to
do statistics with them (min/max/avg/stddev, after discarding outliers).
These are shown at the bottom of the flame graph.

All outliers are also shown, and very serious outliers (intervals longer
than 10ms where no sampling took place) are shown in bold, with a
tooltip that indicates their relative position in time.

This let me see that there was a 2.5 second gap in the profile of my
view that takes 5 seconds, i.e. I was only seeing one half of the
picture.
