### PR TITLE
Update djdt-flamegraph to work with newest django debug toolbar

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 include djdt_flamegraph/flamegraph.pl
+include djdt_flamegraph/static/djdt_flamegraph/djdt_flamegraph.js
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/djdt_flamegraph/static/djdt_flamegraph/djdt_flamegraph.js
+++ b/djdt_flamegraph/static/djdt_flamegraph/djdt_flamegraph.js
@@ -1,0 +1,5 @@
+ (function(){
+     const i = document.querySelector('#djdt-flamegraph-iframe');
+     const tpl = document.querySelector('#djdt-flamegraph-tpl');
+     i.contentWindow.document.write(tpl.innerHTML);
+ }())


### PR DESCRIPTION
Lifecycle methods changed on djdt 2.0 release, and scripts stopped
executing as well. This change requires you to add djdt_flamegraph to
INSTALLED_APPS.